### PR TITLE
:bug: Map .js and .json files correctly

### DIFF
--- a/src/createJestConfig.ts
+++ b/src/createJestConfig.ts
@@ -7,7 +7,8 @@ export const JEST_CONFIG_CODE = `export default {
   testRegex: "\\.(test|spec)\\.ts$",
   testPathIgnorePatterns: ["node_modules"],
   moduleNameMapper: {
-    "(.+)\\.js": ["$1.js", "$1.ts"],
+    "^(.+)\\.js$": ["$1.js", "$1.ts"],
+    "^(.+)\\.json$": ["$1.json"],
   },
 };
 `;


### PR DESCRIPTION
Closes #3 where `vendors.json` file was mapped incorrectly in test configuration